### PR TITLE
[Fix]注文機能_検索の修正

### DIFF
--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -2,12 +2,20 @@ class Admin::OrdersController < ApplicationController
   before_action :authenticate_admin!
 
   def index
-    if params[:customer_id] != nil
+    if params[:customer_id] != nil && params[:status] != nil
+      @orders = Order.where(customer_id: params[:customer_id], status: params[:status]).order(created_at: "DESC").page(params[:page])
+      @heading = "#{Customer.find(params[:customer_id]).name_display}さんの注文履歴「#{Order.statuses_i18n[params[:status]]}」"
+      @customer_id = params[:customer_id]
+      @search_pattern = "1"
+    elsif params[:customer_id] != nil
       @orders = Order.where(customer_id: params[:customer_id]).order(created_at: "DESC").page(params[:page])
       @heading =  "#{Customer.find(params[:customer_id]).name_display}さんの注文履歴"
+      @customer_id = params[:customer_id]
+      @search_pattern = "2"
     elsif params[:status] != nil
       @orders = Order.where(status: params[:status]).order(created_at: "DESC").page(params[:page])
-      @heading = "「#{Order.statuses_i18n[params[:status]]}」の注文履歴"
+      @heading = "注文履歴詳細「#{Order.statuses_i18n[params[:status]]}」"
+      @search_pattern = "3"
     else
       @orders = Order.all.order(created_at: "DESC").page(params[:page])
       @heading = "注文履歴詳細"

--- a/app/views/admin/customers/show.html.erb
+++ b/app/views/admin/customers/show.html.erb
@@ -42,7 +42,7 @@
 
     <div class="px-5 mx-5">
       <%= link_to "編集する", edit_admin_customer_path, class: "btn btn-success mr-5" %>
-      <%= link_to "注文履歴一覧を見る", orders_path, class: "btn btn-secondary ml-5" %>
+      <%= link_to "注文履歴一覧を見る", admin_path(customer_id: @customer.id), class: "btn btn-secondary ml-5" %>
     </div>
   </div>
 </div>

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -9,6 +9,9 @@
         <strong>注文ステータス</strong>
         <%= form_with url: admin_path, method: :get, local: true do |f| %>
           <%= f.select :status, Order.statuses.keys.map{|k| [I18n.t("enums.order.status.#{k}"), k]} %>
+          <% if @search_pattern == "1" || @search_pattern == "2"%>
+            <%= f.hidden_field :customer_id, value: @customer_id %>
+          <% end %>
           <%= f.submit "検索", class: "btn btn-outline-light" %>
         <% end %>
       </th>


### PR DESCRIPTION
#[Fix]注文機機能(管理者)
-会員詳細ページの「注文履歴一覧を見る」のパスを修正
-注文検索機能で「会員」＆「注文ステータス」の両方で検索できるように修正